### PR TITLE
Refactor paths to use CLI/env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,24 @@ Run with the default locations (defined in `main.py`):
 python main.py
 ```
 
-Default paths are:
-- `OLD_PRODUCTS_CSV` → `D:/product_checker/cleaned_products.csv`
-- `NEW_PRODUCTS_CSV` → `D:/bill26668/_ocr_output/merged_receipts.csv`
-- `OUTPUT_DIR` → `D:/product_checker`
+By default the script looks for `old_products.csv` and `new_products.csv` in the current directory and writes outputs under an `output` directory.
+You can override these using command line arguments or environment variables.
 
 ### Supplying Custom Paths
 
-You can override the defaults by setting environment variables before running:
+Use environment variables:
 
 ```bash
 export OLD_PRODUCTS_CSV=/path/to/old_products.csv
 export NEW_PRODUCTS_CSV=/path/to/new_products.csv
 export OUTPUT_DIR=/path/to/output
 python main.py
+```
+
+Or provide command line arguments:
+
+```bash
+python main.py --old-products-csv old.csv --new-products-csv new.csv --output-dir out
 ```
 
 Alternatively, call the `run` function directly from the command line with your own paths:

--- a/clean_csv_products.py
+++ b/clean_csv_products.py
@@ -1,21 +1,38 @@
+import argparse
+import os
+from pathlib import Path
+
 import pandas as pd
 
-# ข้ามแถวหัวรายงาน 4 แถวแรก (header=3 เพราะนับจาก 0)
-df = pd.read_csv("d:/product_checker/สินค้าในpos.csv", header=3)
 
-# เปลี่ยนชื่อคอลัมน์ 'รายการ' เป็น 'name'
-df = df.rename(columns={"รายการ": "name"})
+def run(input_csv: Path | None = None, output_csv: Path | None = None) -> None:
+    """Clean a POS CSV file and output a single-column CSV of unique product names."""
+    input_csv = (
+        Path(os.getenv("POS_CSV", "pos_products.csv")) if input_csv is None else Path(input_csv)
+    )
+    output_csv = (
+        Path(os.getenv("CLEANED_CSV", "cleaned_products.csv"))
+        if output_csv is None
+        else Path(output_csv)
+    )
 
-if "name" not in df.columns:
-    print("Columns:", df.columns.tolist())
-    print("กรุณาตรวจสอบชื่อคอลัมน์สินค้าในไฟล์ CSV แล้วแก้ไขบรรทัด df.rename(...) ให้ถูกต้อง")
-else:
+    df = pd.read_csv(input_csv, header=3)
+    df = df.rename(columns={"รายการ": "name"})
+    if "name" not in df.columns:
+        print("Columns:", df.columns.tolist())
+        print("กรุณาตรวจสอบชื่อคอลัมน์สินค้าในไฟล์ CSV แล้วแก้ไขให้ถูกต้อง")
+        return
+
     df["name"] = df["name"].astype(str).str.strip()
-    # กรองเฉพาะชื่อสินค้าที่ไม่ว่าง, ไม่ใช่ NaN, ไม่ใช่หัวตาราง
     df = df[~df["name"].str.lower().str.contains("nan|^$|วันที่ เวลา สร้างสินค้า", na=True)]
     df = df.drop_duplicates(subset=["name"])
-    # ส่งออกเฉพาะคอลัมน์ name เท่านั้น
-    df[["name"]].to_csv(
-        "d:/product_checker/cleaned_products.csv", index=False, encoding="utf-8-sig"
-    )
-    print("บันทึกไฟล์ cleaned_products.csv เฉพาะคอลัมน์ชื่อสินค้าแล้ว")
+    df[["name"]].to_csv(output_csv, index=False, encoding="utf-8-sig")
+    print(f"บันทึกไฟล์ {output_csv} แล้ว")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Clean POS CSV to unique product list")
+    parser.add_argument("--input-csv", help="POS CSV file to clean")
+    parser.add_argument("--output-csv", help="Destination for cleaned CSV")
+    args = parser.parse_args()
+    run(args.input_csv, args.output_csv)

--- a/filter_matched_products.py
+++ b/filter_matched_products.py
@@ -1,15 +1,34 @@
+import argparse
+import os
+from pathlib import Path
+
 import pandas as pd
 
-df = pd.read_csv("d:/product_checker/matched_products.csv")
 
-# สินค้าที่ต้องตรวจสอบ (score >= 0.90)
-check_df = df[df["score"] >= 0.90].sort_values(by="score", ascending=False)
-check_df.to_csv("d:/product_checker/matched_products_check.csv", index=False, encoding="utf-8-sig")
+def run(matched_csv: Path | None = None, output_dir: Path | None = None) -> None:
+    """Split matched_products.csv into items that need checking and unique items."""
+    matched_csv = (
+        Path(os.getenv("MATCHED_CSV", "matched_products.csv"))
+        if matched_csv is None
+        else Path(matched_csv)
+    )
+    output_dir = Path(os.getenv("OUTPUT_DIR", "output")) if output_dir is None else Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
-# สินค้าที่ไม่ซ้ำ (score < 0.90)
-unique_df = df[df["score"] < 0.90].sort_values(by="score", ascending=False)
-unique_df.to_csv(
-    "d:/product_checker/matched_products_unique.csv", index=False, encoding="utf-8-sig"
-)
+    df = pd.read_csv(matched_csv)
+    check_df = df[df["score"] >= 0.90].sort_values(by="score", ascending=False)
+    unique_df = df[df["score"] < 0.90].sort_values(by="score", ascending=False)
 
-print("บันทึกไฟล์ matched_products_check.csv และ matched_products_unique.csv เรียบร้อยแล้ว")
+    check_path = output_dir / "matched_products_check.csv"
+    unique_path = output_dir / "matched_products_unique.csv"
+    check_df.to_csv(check_path, index=False, encoding="utf-8-sig")
+    unique_df.to_csv(unique_path, index=False, encoding="utf-8-sig")
+    print(f"บันทึกไฟล์ {check_path} และ {unique_path} เรียบร้อยแล้ว")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Filter matched products by score")
+    parser.add_argument("--matched-csv", help="CSV produced by main.py")
+    parser.add_argument("--output-dir", help="Directory for filtered CSV files")
+    args = parser.parse_args()
+    run(args.matched_csv, args.output_dir)

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -87,20 +88,16 @@ def run(
     """
     # Determine file paths using parameters, environment variables, or defaults
     old_products_csv = (
-        Path(os.getenv("OLD_PRODUCTS_CSV", "D:/product_checker/cleaned_products.csv"))
+        Path(os.getenv("OLD_PRODUCTS_CSV", "old_products.csv"))
         if old_products_csv is None
         else Path(old_products_csv)
     )
     new_products_csv = (
-        Path(os.getenv("NEW_PRODUCTS_CSV", "D:/bill26668/_ocr_output/merged_receipts.csv"))
+        Path(os.getenv("NEW_PRODUCTS_CSV", "new_products.csv"))
         if new_products_csv is None
         else Path(new_products_csv)
     )
-    output_dir = (
-        Path(os.getenv("OUTPUT_DIR", "D:/product_checker"))
-        if output_dir is None
-        else Path(output_dir)
-    )
+    output_dir = Path(os.getenv("OUTPUT_DIR", "output")) if output_dir is None else Path(output_dir)
     # Ensure the output directory exists
     output_dir.mkdir(parents=True, exist_ok=True)
     # Load datasets
@@ -142,4 +139,9 @@ def run(
 
 
 if __name__ == "__main__":
-    run()
+    parser = argparse.ArgumentParser(description="Match new products to existing catalog")
+    parser.add_argument("--old-products-csv", help="CSV of existing products")
+    parser.add_argument("--new-products-csv", help="CSV of new products to check")
+    parser.add_argument("--output-dir", help="Directory for output files")
+    args = parser.parse_args()
+    run(args.old_products_csv, args.new_products_csv, args.output_dir)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,5 +1,59 @@
 # tests/test_smoke.py
-def test_imports():
-    import main
+import pandas as pd
 
-    assert True
+import clean_csv_products
+import filter_matched_products
+import main
+
+
+def test_run_creates_output(tmp_path, monkeypatch):
+    # Prepare small datasets
+    old_csv = tmp_path / "old.csv"
+    pd.DataFrame({"name": ["apple", "banana", "cherry"]}).to_csv(old_csv, index=False)
+
+    new_csv = tmp_path / "new.csv"
+    pd.DataFrame({"รายการ": ["apple", "orange", "orange"]}).to_csv(new_csv, index=False)
+
+    # Patch model and similarity to avoid heavy downloads
+    class DummyModel:
+        def encode(self, sentences, convert_to_tensor=True):
+            import torch
+
+            lengths = [float(len(s)) for s in sentences]
+            return torch.tensor(lengths)
+
+    def dummy_cos_sim(a, b):
+        import torch
+
+        return 1 / (1 + torch.abs(b - a.unsqueeze(1)))
+
+    monkeypatch.setattr(main, "SentenceTransformer", lambda _: DummyModel())
+    monkeypatch.setattr(main.util, "cos_sim", dummy_cos_sim)
+
+    main.run(old_csv, new_csv, tmp_path)
+
+    assert (tmp_path / "matched_products.csv").exists()
+
+
+def test_clean_csv_products(tmp_path):
+    raw = tmp_path / "raw.csv"
+    with open(raw, "w", encoding="utf-8-sig") as f:
+        f.write("a\n" * 3)
+        f.write("รายการ\n")
+        f.write("A\nA\nB\nวันที่ เวลา สร้างสินค้า\n")
+
+    output = tmp_path / "clean.csv"
+    clean_csv_products.run(raw, output)
+
+    df = pd.read_csv(output)
+    assert df["name"].tolist() == ["A", "B"]
+
+
+def test_filter_matched_products(tmp_path):
+    matched = tmp_path / "matched.csv"
+    pd.DataFrame({"score": [0.95, 0.5]}).to_csv(matched, index=False)
+
+    filter_matched_products.run(matched, tmp_path)
+
+    assert (tmp_path / "matched_products_check.csv").exists()
+    assert (tmp_path / "matched_products_unique.csv").exists()


### PR DESCRIPTION
## Summary
- remove hard-coded Windows paths
- add argparse support for `main.py`, `clean_csv_products.py`, and `filter_matched_products.py`
- document path overrides
- expand tests for all scripts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68870af90b4c8328ae283b72e1ec7950