### PR TITLE
Add interactive CSV prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python main.py
 ```
 
 By default the script looks for `old_products.csv` and `new_products.csv` in the current directory and writes outputs under an `output` directory.
-You can override these using command line arguments or environment variables.
+You can override these using command line arguments or environment variables. If neither a command line argument nor an environment variable is supplied for a CSV path, `main.py` will prompt you to enter the file interactively.
 
 ### Supplying Custom Paths
 

--- a/main.py
+++ b/main.py
@@ -8,6 +8,19 @@ import pandas as pd
 from sentence_transformers import SentenceTransformer, util
 
 
+def prompt_csv_path(prompt_text: str) -> Path:
+    """Interactively prompt for a CSV file path until it exists."""
+    while True:
+        available = [p.name for p in Path(".").glob("*.csv")]
+        if available:
+            print("Available CSV files: " + ", ".join(available))
+        path_str = input(prompt_text).strip()
+        path = Path(path_str).expanduser()
+        if path.is_file():
+            return path.resolve()
+        print(f"{path} is not a valid file. Please try again.")
+
+
 def check_product_similarity(
     new_product: str,
     old_product_names: List[str],
@@ -145,4 +158,13 @@ if __name__ == "__main__":
     parser.add_argument("--new-products-csv", help="CSV of new products to check")
     parser.add_argument("--output-dir", help="Directory for output files")
     args = parser.parse_args()
-    run(args.old_products_csv, args.new_products_csv, args.output_dir)
+
+    old_csv = args.old_products_csv or os.getenv("OLD_PRODUCTS_CSV")
+    new_csv = args.new_products_csv or os.getenv("NEW_PRODUCTS_CSV")
+
+    if old_csv is None:
+        old_csv = prompt_csv_path("Path to old products CSV: ")
+    if new_csv is None:
+        new_csv = prompt_csv_path("Path to new products CSV: ")
+
+    run(old_csv, new_csv, args.output_dir)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -57,3 +57,15 @@ def test_filter_matched_products(tmp_path):
 
     assert (tmp_path / "matched_products_check.csv").exists()
     assert (tmp_path / "matched_products_unique.csv").exists()
+
+
+def test_prompt_csv_path(monkeypatch, tmp_path):
+    csv = tmp_path / "example.csv"
+    csv.write_text("a,b\n1,2")
+    monkeypatch.chdir(tmp_path)
+
+    responses = iter(["missing.csv", "example.csv"])
+    monkeypatch.setattr("builtins.input", lambda _: next(responses))
+
+    result = main.prompt_csv_path("Enter: ")
+    assert result == csv


### PR DESCRIPTION
## Summary
- add `prompt_csv_path` helper for interactive file selection
- prompt for paths in `main.py` when no CLI argument or env var was given
- document interactive prompt behavior
- test that `prompt_csv_path` loops until a valid path is entered

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688735cff6708328ac3b2390d610d9d0