### PR TITLE
Ensure list outputs from tolist

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import argparse
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import pandas as pd
 
@@ -28,7 +28,8 @@ def check_product_similarity(
     old_embeddings,
     model: SentenceTransformer,
     top_k: int = 3,
-) -> List[Tuple[str, float, str, str]]:
+    include_vectors: bool = False,
+) -> Union[List[Tuple[str, float]], List[Tuple[str, float, str, str]]]:
     """
     Compute the similarity between a new product name and a list of old product names using embeddings.
     Returns the top_k most similar old product names with their cosine similarity scores and vector information.
@@ -43,43 +44,50 @@ def check_product_similarity(
     """
     # Encode the new product name into the same embedding space as old_product_names
     new_embedding = model.encode([new_product], convert_to_tensor=True)
-    # Convert tensor to list for display - get complete vector for manual calculation
-    try:
-        # Get the complete vector for new product
-        if hasattr(new_embedding, 'shape') and len(new_embedding.shape) > 1:
-            new_vector_list = new_embedding[0].tolist()
-        else:
-            new_vector_list = new_embedding.tolist()
-        # Format as comma-separated values for easy copying
-        new_vector_str = ",".join([f"{x:.6f}" for x in new_vector_list])
-    except Exception as e:
-        new_vector_str = f"Vector conversion error: {str(e)}"
+    new_vector_str = ""
+    if include_vectors:
+        # Convert tensor to list for display - get complete vector for manual calculation
+        try:
+            # Get the complete vector for new product
+            if hasattr(new_embedding, 'shape') and len(new_embedding.shape) > 1:
+                converted = new_embedding[0].tolist()
+            else:
+                converted = new_embedding.tolist()
+            new_vector_list = converted if isinstance(converted, list) else [converted]
+            # Format as comma-separated values for easy copying
+            new_vector_str = ",".join([f"{x:.6f}" for x in new_vector_list])
+        except Exception as e:
+            new_vector_str = f"Vector conversion error: {str(e)}"
     
     # Compute cosine similarity between the new product embedding and all old product embeddings
     cos_scores = util.cos_sim(new_embedding, old_embeddings)[0]
     # Get the top_k highest similarity scores and their indices
     top_results = cos_scores.topk(k=top_k)
-    result: List[Tuple[str, float, str, str]] = []
+    result: List[Tuple] = []
     # Pair each top score with the corresponding old product name and vectors
     for score, idx in zip(top_results[0], top_results[1]):
-        try:
-            # Get the complete vector for old product - handle different tensor shapes
-            idx_int = int(idx)
-            old_tensor = old_embeddings[idx_int]
-            
-            # Check if it's a tensor or scalar
-            if hasattr(old_tensor, 'tolist'):
-                old_vector_list = old_tensor.tolist()
-            elif hasattr(old_tensor, 'item'):
-                old_vector_list = [old_tensor.item()]
-            else:
-                old_vector_list = [float(old_tensor)]
-                
-            # Format as comma-separated values for easy copying
-            old_vector_str = ",".join([f"{x:.6f}" for x in old_vector_list])
-        except Exception as e:
-            old_vector_str = f"Vector conversion error: {str(e)}"
-        result.append((old_product_names[int(idx)], float(score), new_vector_str, old_vector_str))
+        if include_vectors:
+            try:
+                # Get the complete vector for old product - handle different tensor shapes
+                idx_int = int(idx)
+                old_tensor = old_embeddings[idx_int]
+
+                # Check if it's a tensor or scalar
+                if hasattr(old_tensor, 'tolist'):
+                    converted = old_tensor.tolist()
+                    old_vector_list = converted if isinstance(converted, list) else [converted]
+                elif hasattr(old_tensor, 'item'):
+                    old_vector_list = [old_tensor.item()]
+                else:
+                    old_vector_list = [float(old_tensor)]
+
+                # Format as comma-separated values for easy copying
+                old_vector_str = ",".join([f"{x:.6f}" for x in old_vector_list])
+            except Exception as e:
+                old_vector_str = f"Vector conversion error: {str(e)}"
+            result.append((old_product_names[int(idx)], float(score), new_vector_str, old_vector_str))
+        else:
+            result.append((old_product_names[int(idx)], float(score)))
     return result
 
 
@@ -169,7 +177,12 @@ def run(
     # Compute top 3 similar old products for each new product
     for new_product in new_product_names:
         top_matches = check_product_similarity(
-            new_product, old_product_names, old_embeddings, model, top_k=3
+            new_product,
+            old_product_names,
+            old_embeddings,
+            model,
+            top_k=3,
+            include_vectors=True,
         )
         for old_name, score, new_vector, old_vector in top_matches:
             output_rows.append(
@@ -182,12 +195,13 @@ def run(
                     "calculation_method": "1) แปลงชื่อสินค้าเป็น embedding vectors 2) คำนวณ cosine similarity 3) หาค่าความคล้ายคลึงสูงสุด"
                 }
             )
-    # Save the matching results to CSV with timestamp to avoid permission issues
+    # Save the matching results to a consistent filename
     output_df = pd.DataFrame(output_rows)
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    matched_path = output_dir / f"matched_products_{timestamp}.csv"
+    matched_path = output_dir / "matched_products.csv"
     output_df.to_csv(matched_path, index=False, encoding="utf-8-sig")
-    print(f"บันทึกผลลัพธ์ที่ {matched_path} เรียบร้อยแล้ว (encoding utf-8-sig สำหรับ Excel)")
+    print(
+        f"บันทึกผลลัพธ์ที่ {matched_path} เรียบร้อยแล้ว (encoding utf-8-sig สำหรับ Excel)"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add optional `include_vectors` flag to `check_product_similarity`
- handle scalar `tolist()` outputs for new and old embeddings
- call similarity helper with `include_vectors=True` and save results to `matched_products.csv`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f733117e0832889f69a77160b748b