### PR TITLE
Use tensor.item for GPU-safe similarity scores

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,7 +67,7 @@ def check_product_similarity(
 
     # Pair each top score with the corresponding old product name
     return [
-        (old_product_names[int(idx)], float(score))
+        (old_product_names[int(idx)], score.item())
         for score, idx in zip(top_results[0], top_results[1])
     ]
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -66,3 +66,45 @@ def test_check_product_similarity_negative_top_k(monkeypatch):
 
     with pytest.raises(ValueError):
         main.check_product_similarity("a", old_names, old_emb, model, top_k=-1)
+
+
+def test_check_product_similarity_gpu_tensor(monkeypatch):
+    class DummyModel:
+        def encode(self, sentences, convert_to_tensor=True):
+            # Embeddings are not used in the dummy cosine similarity below
+            return [0] * len(sentences)
+
+    class FakeGPUScore:
+        def __init__(self, value):
+            self.value = value
+
+        def item(self):
+            return self.value
+
+        def cpu(self):
+            return self
+
+        def __float__(self):  # pragma: no cover - used to emulate CUDA restriction
+            raise TypeError("Can't convert CUDA tensor to float")
+
+    class FakeCosScores:
+        def __init__(self, scores):
+            self.scores = scores
+
+        def topk(self, k):
+            top_scores = [FakeGPUScore(v) for v in self.scores[:k]]
+            top_indices = list(range(k))
+            return top_scores, top_indices
+
+    def dummy_cos_sim(a, b):
+        # Return predefined scores in descending order
+        return [FakeCosScores([1.0, 0.5, 0.2])]
+
+    monkeypatch.setattr(main.util, "cos_sim", dummy_cos_sim)
+
+    model = DummyModel()
+    old_names = ["a", "b", "c"]
+    old_emb = [0, 0, 0]
+
+    result = main.check_product_similarity("new", old_names, old_emb, model, top_k=2)
+    assert result == [("a", 1.0), ("b", 0.5)]

--- a/torch.py
+++ b/torch.py
@@ -56,7 +56,7 @@ class Tensor:
 
     def __iter__(self):
         for x in self.data.flatten():
-            yield float(x)
+            yield Tensor(x)
 
     def __len__(self):
         return len(self.data.flatten())
@@ -65,6 +65,12 @@ class Tensor:
         return Tensor(self.data[idx])
 
     def __float__(self):
+        return float(self.data)
+
+    def __int__(self):
+        return int(self.data)
+
+    def item(self):
         return float(self.data)
 
     def tolist(self):


### PR DESCRIPTION
## Summary
- Use `score.item()` when collecting similarity scores to handle GPU tensors
- Add unit test simulating GPU tensor to ensure float conversion is avoided
- Expand torch stub with `item`, iterator returning tensors, and integer conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68972de8fe7883289c01a3c4e734a586