### PR TITLE
Handle quoted CSV paths in prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,10 +15,10 @@ def prompt_csv_path(prompt_text: str) -> Path:
         if available:
             print("Available CSV files: " + ", ".join(available))
         path_str = input(prompt_text).strip()
-        path = Path(path_str).expanduser()
+        path = Path(path_str.strip("'\"")).expanduser().resolve()
         if path.is_file():
-            return path.resolve()
-        print(f"{path} is not a valid file. Please try again.")
+            return path
+        print(f"{path} is not a valid file. Please try again without quotes.")
 
 
 def check_product_similarity(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -64,7 +64,7 @@ def test_prompt_csv_path(monkeypatch, tmp_path):
     csv.write_text("a,b\n1,2")
     monkeypatch.chdir(tmp_path)
 
-    responses = iter(["missing.csv", "example.csv"])
+    responses = iter(['"missing.csv"', '"example.csv"'])
     monkeypatch.setattr("builtins.input", lambda _: next(responses))
 
     result = main.prompt_csv_path("Enter: ")


### PR DESCRIPTION
## Summary
- Strip surrounding quotes from CSV paths in `prompt_csv_path`
- Resolve user-provided paths before validation and advise against quoted input
- Test `prompt_csv_path` with quoted responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68973ea700308328b6f55428f9779a99