### PR TITLE
Resolve env path to absolute with expanduser

### DIFF
--- a/clean_csv_products.py
+++ b/clean_csv_products.py
@@ -8,12 +8,18 @@ import pandas as pd
 def run(input_csv: Path | None = None, output_csv: Path | None = None) -> None:
     """Clean a POS CSV file and output a single-column CSV of unique product names."""
     input_csv = (
-        Path(os.getenv("POS_CSV", "pos_products.csv")) if input_csv is None else Path(input_csv)
+        (Path(os.getenv("POS_CSV", "pos_products.csv")) if input_csv is None else Path(input_csv))
+        .expanduser()
+        .resolve()
     )
     output_csv = (
-        Path(os.getenv("CLEANED_CSV", "cleaned_products.csv"))
-        if output_csv is None
-        else Path(output_csv)
+        (
+            Path(os.getenv("CLEANED_CSV", "cleaned_products.csv"))
+            if output_csv is None
+            else Path(output_csv)
+        )
+        .expanduser()
+        .resolve()
     )
 
     df = pd.read_csv(input_csv, header=3)

--- a/filter_matched_products.py
+++ b/filter_matched_products.py
@@ -8,11 +8,19 @@ import pandas as pd
 def run(matched_csv: Path | None = None, output_dir: Path | None = None) -> None:
     """Split matched_products.csv into items that need checking and unique items."""
     matched_csv = (
-        Path(os.getenv("MATCHED_CSV", "matched_products.csv"))
-        if matched_csv is None
-        else Path(matched_csv)
+        (
+            Path(os.getenv("MATCHED_CSV", "matched_products.csv"))
+            if matched_csv is None
+            else Path(matched_csv)
+        )
+        .expanduser()
+        .resolve()
     )
-    output_dir = Path(os.getenv("OUTPUT_DIR", "output")) if output_dir is None else Path(output_dir)
+    output_dir = (
+        (Path(os.getenv("OUTPUT_DIR", "output")) if output_dir is None else Path(output_dir))
+        .expanduser()
+        .resolve()
+    )
     output_dir.mkdir(parents=True, exist_ok=True)
 
     df = pd.read_csv(matched_csv)

--- a/main.py
+++ b/main.py
@@ -134,16 +134,28 @@ def run(
     """
     # Determine file paths using parameters, environment variables, or defaults
     old_products_csv = (
-        Path(os.getenv("OLD_PRODUCTS_CSV", "old_products.csv"))
-        if old_products_csv is None
-        else Path(old_products_csv)
+        (
+            Path(os.getenv("OLD_PRODUCTS_CSV", "old_products.csv"))
+            if old_products_csv is None
+            else Path(old_products_csv)
+        )
+        .expanduser()
+        .resolve()
     )
     new_products_csv = (
-        Path(os.getenv("NEW_PRODUCTS_CSV", "new_products.csv"))
-        if new_products_csv is None
-        else Path(new_products_csv)
+        (
+            Path(os.getenv("NEW_PRODUCTS_CSV", "new_products.csv"))
+            if new_products_csv is None
+            else Path(new_products_csv)
+        )
+        .expanduser()
+        .resolve()
     )
-    output_dir = Path(os.getenv("OUTPUT_DIR", "output")) if output_dir is None else Path(output_dir)
+    output_dir = (
+        (Path(os.getenv("OUTPUT_DIR", "output")) if output_dir is None else Path(output_dir))
+        .expanduser()
+        .resolve()
+    )
     # Ensure the output directory exists
     output_dir.mkdir(parents=True, exist_ok=True)
     # Load datasets


### PR DESCRIPTION
## Summary
- Resolve user (`~`) and relative paths for old/new product CSVs and output dir in `main.py`
- Expand environment variable paths for POS CSV cleaning
- Ensure matched product filtering resolves tilde and relative paths
- Format code with Black for consistent style

## Testing
- `python - <<'PY'\nimport clean_csv_products; clean_csv_products.run()\nPY`
- `python - <<'PY'\nimport filter_matched_products; filter_matched_products.run()\nPY`
- `python - <<'PY'\nimport main; main.run()\nPY`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689741a454b48328a3390f786cfd28a8