### PR TITLE
Remove duplicate path assignments in run

### DIFF
--- a/main.py
+++ b/main.py
@@ -156,18 +156,6 @@ def run(
         .expanduser()
         .resolve()
     )
-        Path(os.getenv("OLD_PRODUCTS_CSV", "old_products.csv"))
-        if old_products_csv is None
-        else Path(old_products_csv)
-    ).expanduser().resolve()
-    new_products_csv = (
-        Path(os.getenv("NEW_PRODUCTS_CSV", "new_products.csv"))
-        if new_products_csv is None
-        else Path(new_products_csv)
-    ).expanduser().resolve()
-    output_dir = (
-        Path(os.getenv("OUTPUT_DIR", "output")) if output_dir is None else Path(output_dir)
-    ).expanduser().resolve()
     # Ensure the output directory exists
     output_dir.mkdir(parents=True, exist_ok=True)
     # Load datasets


### PR DESCRIPTION
## Summary
- clean up run() by removing duplicate path-resolution assignments
- ensure function uses a single set of resolved paths

## Testing
- `black main.py`
- `pytest` *(fails: IndentationError in clean_csv_products.py)*

------
https://chatgpt.com/codex/tasks/task_e_68974cc577d08328b4a09800cde7f90f