### PR TITLE
refactor: streamline CSV cleaning path setup

### DIFF
--- a/clean_csv_products.py
+++ b/clean_csv_products.py
@@ -8,7 +8,6 @@ import pandas as pd
 def run(input_csv: Path | None = None, output_csv: Path | None = None) -> None:
     """Clean a POS CSV file and output a single-column CSV of unique product names."""
     input_csv = (
-
         (Path(os.getenv("POS_CSV", "pos_products.csv")) if input_csv is None else Path(input_csv))
         .expanduser()
         .resolve()
@@ -22,15 +21,6 @@ def run(input_csv: Path | None = None, output_csv: Path | None = None) -> None:
         .expanduser()
         .resolve()
     )
-
-        Path(os.getenv("POS_CSV", "pos_products.csv")) if input_csv is None else Path(input_csv)
-    ).expanduser().resolve()
-    output_csv = (
-        Path(os.getenv("CLEANED_CSV", "cleaned_products.csv"))
-        if output_csv is None
-        else Path(output_csv)
-    ).expanduser().resolve()
-main
 
     df = pd.read_csv(input_csv, header=3)
     df = df.rename(columns={"รายการ": "name"})


### PR DESCRIPTION
## Summary
- remove redundant path resolution and stray `main` string in `clean_csv_products.py`
- ensure `run` transitions from path setup straight to CSV loading
- format with Black for consistency

## Testing
- `black clean_csv_products.py`
- `pytest -q` *(fails: IndentationError in main.py and filter_matched_products.py)*

------
https://chatgpt.com/codex/tasks/task_e_68974efcdca48328899cd06bed647fb1