### PR TITLE
Remove duplicated path setup in filter script

### DIFF
--- a/filter_matched_products.py
+++ b/filter_matched_products.py
@@ -8,7 +8,6 @@ import pandas as pd
 def run(matched_csv: Path | None = None, output_dir: Path | None = None) -> None:
     """Split matched_products.csv into items that need checking and unique items."""
     matched_csv = (
-
         (
             Path(os.getenv("MATCHED_CSV", "matched_products.csv"))
             if matched_csv is None
@@ -22,14 +21,7 @@ def run(matched_csv: Path | None = None, output_dir: Path | None = None) -> None
         .expanduser()
         .resolve()
     )
-        Path(os.getenv("MATCHED_CSV", "matched_products.csv"))
-        if matched_csv is None
-        else Path(matched_csv)
-    ).expanduser().resolve()
-    output_dir = (
-        Path(os.getenv("OUTPUT_DIR", "output")) if output_dir is None else Path(output_dir)
-    ).expanduser().resolve()
-main
+
     output_dir.mkdir(parents=True, exist_ok=True)
 
     df = pd.read_csv(matched_csv)


### PR DESCRIPTION
## Summary
- remove duplicated `matched_csv` and `output_dir` assignments in `filter_matched_products.py`
- ensure single path setup before creating output directory

## Testing
- `pytest -q` *(fails: IndentationError: unexpected indent in clean_csv_products.py)*

------
https://chatgpt.com/codex/tasks/task_e_6897516783148328ae09fce57cc73b73